### PR TITLE
Add <source> config to maven-javadoc-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,7 @@
         <version>3.1.1</version>
         <configuration>
           <doclint>none</doclint>
+          <source>8</source>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
## Description of the change

> This fixes errors when building for JDK 11 and 12 https://bugs.openjdk.java.net/browse/JDK-8212233

## Type of change
- [X ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)
