### PR TITLE
Provide path

### DIFF
--- a/src/main/java/com/saasquatch/jsonschemainferrer/EnumExtractorInput.java
+++ b/src/main/java/com/saasquatch/jsonschemainferrer/EnumExtractorInput.java
@@ -15,11 +15,13 @@ public final class EnumExtractorInput {
 
   private final Collection<? extends JsonNode> samples;
   private final SpecVersion specVersion;
+  private final String path;
 
   EnumExtractorInput(@Nonnull Collection<? extends JsonNode> samples,
-      @Nonnull SpecVersion specVersion) {
+      @Nonnull SpecVersion specVersion, @Nonnull String path) {
     this.samples = samples;
     this.specVersion = specVersion;
+    this.path = path;
   }
 
   /**
@@ -36,6 +38,14 @@ public final class EnumExtractorInput {
   @Nonnull
   public SpecVersion getSpecVersion() {
     return specVersion;
+  }
+
+  /**
+   * @return The json path of the current traversal.
+   */
+  @Nonnull
+  public String getPath() {
+    return path;
   }
 
 }

--- a/src/main/java/com/saasquatch/jsonschemainferrer/FormatInferrerInput.java
+++ b/src/main/java/com/saasquatch/jsonschemainferrer/FormatInferrerInput.java
@@ -12,10 +12,12 @@ public final class FormatInferrerInput {
 
   private final JsonNode sample;
   private final SpecVersion specVersion;
+  private final String path;
 
-  FormatInferrerInput(@Nonnull JsonNode sample, @Nonnull SpecVersion specVersion) {
+  FormatInferrerInput(@Nonnull JsonNode sample, @Nonnull SpecVersion specVersion, @Nonnull String path) {
     this.sample = sample;
     this.specVersion = specVersion;
+    this.path = path;
   }
 
   /**
@@ -29,6 +31,14 @@ public final class FormatInferrerInput {
   @Nonnull
   public SpecVersion getSpecVersion() {
     return specVersion;
+  }
+
+  /**
+   * @return The json path of the current traversal.
+   */
+  @Nonnull
+  public String getPath() {
+    return path;
   }
 
 }

--- a/src/main/java/com/saasquatch/jsonschemainferrer/GenericSchemaFeatureInput.java
+++ b/src/main/java/com/saasquatch/jsonschemainferrer/GenericSchemaFeatureInput.java
@@ -17,14 +17,16 @@ public final class GenericSchemaFeatureInput {
   private final Collection<? extends JsonNode> samples;
   private final String type;
   private final SpecVersion specVersion;
+  private final String path;
 
   GenericSchemaFeatureInput(@Nonnull ObjectNode schema,
       @Nonnull Collection<? extends JsonNode> samples, @Nullable String type,
-      @Nonnull SpecVersion specVersion) {
+      @Nonnull SpecVersion specVersion, @Nonnull String path) {
     this.schema = schema;
     this.samples = samples;
     this.type = type;
     this.specVersion = specVersion;
+    this.path = path;
   }
 
   /**
@@ -58,6 +60,14 @@ public final class GenericSchemaFeatureInput {
   @Nonnull
   public SpecVersion getSpecVersion() {
     return specVersion;
+  }
+
+  /**
+   * @return The json path of the current traversal.
+   */
+  @Nonnull
+  public String getPath() {
+    return path;
   }
 
 }

--- a/src/main/java/com/saasquatch/jsonschemainferrer/JsonSchemaInferrer.java
+++ b/src/main/java/com/saasquatch/jsonschemainferrer/JsonSchemaInferrer.java
@@ -136,7 +136,10 @@ public final class JsonSchemaInferrer {
           .map(this::preProcessSample).collect(Collectors.toList());
       final ObjectNode newProperty = newObject();
       handleDescriptionGeneration(newProperty, fieldName);
-      final String objectPath = path + "." + fieldName;
+
+      // Add Field to Path
+      final String objectPath = "%s[%s]".formatted(path, JsonNodeFactory.instance.textNode(fieldName));
+
       final Set<ObjectNode> anyOfs = getAnyOfsFromSamples(processedSamples, objectPath);
       switch (anyOfs.size()) {
         case 0:
@@ -177,7 +180,7 @@ public final class JsonSchemaInferrer {
         .map(this::preProcessSample)
         .collect(Collectors.toList());
     final ObjectNode items;
-    final String arrayPath = path + "[*]";
+    final String arrayPath = "%s[*]".formatted(path);
     final Set<ObjectNode> anyOfs = getAnyOfsFromSamples(processedSamples, arrayPath);
     switch (anyOfs.size()) {
       case 0:

--- a/src/main/java/com/saasquatch/jsonschemainferrer/JsonSchemaInferrer.java
+++ b/src/main/java/com/saasquatch/jsonschemainferrer/JsonSchemaInferrer.java
@@ -1,33 +1,16 @@
 package com.saasquatch.jsonschemainferrer;
 
-import static com.saasquatch.jsonschemainferrer.JunkDrawer.format;
-import static com.saasquatch.jsonschemainferrer.JunkDrawer.getAllFieldNames;
-import static com.saasquatch.jsonschemainferrer.JunkDrawer.getAllValuesForFieldName;
-import static com.saasquatch.jsonschemainferrer.JunkDrawer.isNull;
-import static com.saasquatch.jsonschemainferrer.JunkDrawer.isTextualFloat;
-import static com.saasquatch.jsonschemainferrer.JunkDrawer.newArray;
-import static com.saasquatch.jsonschemainferrer.JunkDrawer.newObject;
-import static com.saasquatch.jsonschemainferrer.JunkDrawer.stream;
-import static com.saasquatch.jsonschemainferrer.JunkDrawer.stringColToArrayDistinct;
-
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.ValueNode;
+import com.fasterxml.jackson.databind.node.*;
 import com.saasquatch.jsonschemainferrer.annotations.VisibleForTesting;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static com.saasquatch.jsonschemainferrer.JunkDrawer.*;
 
 /**
  * Infer JSON schema based on sample JSONs. This class is immutable and thread safe.
@@ -97,7 +80,7 @@ public final class JsonSchemaInferrer {
         samples.stream().map(this::preProcessSample).collect(Collectors.toList());
     final ObjectNode schema = newObject();
     schema.put(Consts.Fields.DOLLAR_SCHEMA, specVersion.getMetaSchemaUrl());
-    final Set<ObjectNode> anyOfs = getAnyOfsFromSamples(processedSamples);
+    final Set<ObjectNode> anyOfs = getAnyOfsFromSamples(processedSamples, "$");
     switch (anyOfs.size()) {
       case 0:
         // anyOfs cannot be empty here, since we force inputs to be non-empty
@@ -109,7 +92,7 @@ public final class JsonSchemaInferrer {
       default: {
         schema.set(Consts.Fields.ANY_OF, newArray(anyOfs));
         // This is an anyOf schema. No type available.
-        processGenericSchemaFeature(schema, processedSamples, null);
+        processGenericSchemaFeature(schema, processedSamples, null, "$");
         break;
       }
     }
@@ -140,7 +123,7 @@ public final class JsonSchemaInferrer {
    * Handle object samples
    */
   @Nullable
-  private ObjectNode processObjects(@Nonnull Collection<ObjectNode> objectNodes) {
+  private ObjectNode processObjects(@Nonnull Collection<ObjectNode> objectNodes, @Nonnull String path) {
     if (objectNodes.isEmpty()) {
       return null;
     }
@@ -153,7 +136,8 @@ public final class JsonSchemaInferrer {
           .map(this::preProcessSample).collect(Collectors.toList());
       final ObjectNode newProperty = newObject();
       handleDescriptionGeneration(newProperty, fieldName);
-      final Set<ObjectNode> anyOfs = getAnyOfsFromSamples(processedSamples);
+      final String objectPath = path + "." + fieldName;
+      final Set<ObjectNode> anyOfs = getAnyOfsFromSamples(processedSamples, objectPath);
       switch (anyOfs.size()) {
         case 0:
           // anyOfs cannot be empty here, since we should have at least one match of the fieldName
@@ -165,7 +149,7 @@ public final class JsonSchemaInferrer {
         default: {
           newProperty.set(Consts.Fields.ANY_OF, newArray(anyOfs));
           // This is an anyOf schema. No type available.
-          processGenericSchemaFeature(newProperty, processedSamples, null);
+          processGenericSchemaFeature(newProperty, processedSamples, null, objectPath);
           break;
         }
       }
@@ -175,7 +159,7 @@ public final class JsonSchemaInferrer {
     if (properties.size() > 0) {
       schema.set(Consts.Fields.PROPERTIES, properties);
     }
-    processGenericSchemaFeature(schema, objectNodes, Consts.Types.OBJECT);
+    processGenericSchemaFeature(schema, objectNodes, Consts.Types.OBJECT, path);
     return schema;
   }
 
@@ -183,7 +167,7 @@ public final class JsonSchemaInferrer {
    * Handle array samples
    */
   @Nullable
-  private ObjectNode processArrays(@Nonnull Collection<ArrayNode> arrayNodes) {
+  private ObjectNode processArrays(@Nonnull Collection<ArrayNode> arrayNodes, @Nonnull String path) {
     if (arrayNodes.isEmpty()) {
       return null;
     }
@@ -193,7 +177,8 @@ public final class JsonSchemaInferrer {
         .map(this::preProcessSample)
         .collect(Collectors.toList());
     final ObjectNode items;
-    final Set<ObjectNode> anyOfs = getAnyOfsFromSamples(processedSamples);
+    final String arrayPath = path + "[*]";
+    final Set<ObjectNode> anyOfs = getAnyOfsFromSamples(processedSamples, arrayPath);
     switch (anyOfs.size()) {
       case 0:
         // anyOfs can be empty here, since the original array can be empty
@@ -211,7 +196,7 @@ public final class JsonSchemaInferrer {
     if (items.size() > 0) {
       schema.set(Consts.Fields.ITEMS, items);
     }
-    processGenericSchemaFeature(schema, arrayNodes, Consts.Types.ARRAY);
+    processGenericSchemaFeature(schema, arrayNodes, Consts.Types.ARRAY, path);
     return schema;
   }
 
@@ -219,7 +204,7 @@ public final class JsonSchemaInferrer {
    * Handle primitive samples
    */
   @Nonnull
-  private Set<ObjectNode> processPrimitives(@Nonnull Collection<ValueNode> valueNodes) {
+  private Set<ObjectNode> processPrimitives(@Nonnull Collection<ValueNode> valueNodes, @Nonnull String path) {
     if (valueNodes.isEmpty()) {
       return Collections.emptySet();
     }
@@ -236,7 +221,7 @@ public final class JsonSchemaInferrer {
       final ObjectNode newAnyOf = newObject();
       final String type = inferPrimitiveType(valueNode, allNumbersAreIntegers);
       newAnyOf.put(Consts.Fields.TYPE, type);
-      final String format = inferFormat(valueNode);
+      final String format = inferFormat(valueNode, path);
       if (format != null) {
         newAnyOf.put(Consts.Fields.FORMAT, format);
       }
@@ -250,14 +235,14 @@ public final class JsonSchemaInferrer {
       @Nonnull
       final PrimitivesSummary primitivesSummary =
           Objects.requireNonNull(primitivesSummaryMap.getPrimitivesSummary(type, format));
-      processGenericSchemaFeature(anyOf, primitivesSummary.getSamples(), type);
+      processGenericSchemaFeature(anyOf, primitivesSummary.getSamples(), type, path);
     }
     return anyOfs;
   }
 
   @Nonnull
   private ObjectNode enumExtractionResultToSchema(
-      @Nonnull Collection<? extends JsonNode> enumExtractionResult) {
+      @Nonnull Collection<? extends JsonNode> enumExtractionResult, @Nonnull String path) {
     Objects.requireNonNull(enumExtractionResult);
     if (enumExtractionResult.isEmpty()) {
       throw new IllegalStateException("Empty enum group encountered");
@@ -266,7 +251,7 @@ public final class JsonSchemaInferrer {
     enumExtractionResult.stream().distinct().forEach(enumArray::add);
     final ObjectNode schema = newObject();
     schema.set(Consts.Fields.ENUM, enumArray);
-    processGenericSchemaFeature(schema, enumExtractionResult, null);
+    processGenericSchemaFeature(schema, enumExtractionResult, null, path);
     return schema;
   }
 
@@ -278,9 +263,9 @@ public final class JsonSchemaInferrer {
    */
   @Nonnull
   private Set<ObjectNode> getAnyOfsFromSamples(
-      @Nonnull Collection<? extends JsonNode> processedSamples) {
+      @Nonnull Collection<? extends JsonNode> processedSamples, @Nonnull String path) {
     final Collection<Collection<? extends JsonNode>> enumExtractionResults =
-        getEnumExtractionResults(processedSamples);
+        getEnumExtractionResults(processedSamples, path);
     final Collection<ObjectNode> objectNodes = new ArrayList<>();
     final Collection<ArrayNode> arrayNodes = new ArrayList<>();
     final Collection<ValueNode> valueNodes = new ArrayList<>();
@@ -299,13 +284,14 @@ public final class JsonSchemaInferrer {
     }
     final Set<ObjectNode> anyOfs = new HashSet<>();
     // Enums
-    enumExtractionResults.stream().map(this::enumExtractionResultToSchema).forEach(anyOfs::add);
+    enumExtractionResults.stream().map((Collection<? extends JsonNode> enumExtractionResult) -> enumExtractionResultToSchema(
+            enumExtractionResult, path)).forEach(anyOfs::add);
     // Objects
-    Optional.ofNullable(processObjects(objectNodes)).ifPresent(anyOfs::add);
+    Optional.ofNullable(processObjects(objectNodes, path)).ifPresent(anyOfs::add);
     // Arrays
-    Optional.ofNullable(processArrays(arrayNodes)).ifPresent(anyOfs::add);
+    Optional.ofNullable(processArrays(arrayNodes, path)).ifPresent(anyOfs::add);
     // Primitives
-    anyOfs.addAll(processPrimitives(valueNodes));
+    anyOfs.addAll(processPrimitives(valueNodes, path));
     postProcessAnyOfs(anyOfs);
     return Collections.unmodifiableSet(anyOfs);
   }
@@ -368,8 +354,8 @@ public final class JsonSchemaInferrer {
   }
 
   private Collection<Collection<? extends JsonNode>> getEnumExtractionResults(
-      @Nonnull Collection<? extends JsonNode> samples) {
-    final EnumExtractorInput input = new EnumExtractorInput(samples, specVersion);
+      @Nonnull Collection<? extends JsonNode> samples, @Nonnull String path) {
+    final EnumExtractorInput input = new EnumExtractorInput(samples, specVersion, path);
     final Collection<Collection<? extends JsonNode>> enumExtractionResults =
         enumExtractor.extractEnums(input);
     return Objects.requireNonNull(enumExtractionResults);
@@ -393,15 +379,15 @@ public final class JsonSchemaInferrer {
   }
 
   @Nullable
-  private String inferFormat(@Nonnull JsonNode sample) {
-    final FormatInferrerInput input = new FormatInferrerInput(sample, specVersion);
+  private String inferFormat(@Nonnull JsonNode sample, @Nonnull String path) {
+    final FormatInferrerInput input = new FormatInferrerInput(sample, specVersion, path);
     return formatInferrer.inferFormat(input);
   }
 
   private void processGenericSchemaFeature(@Nonnull ObjectNode schema,
-      @Nonnull Collection<? extends JsonNode> samples, @Nullable String type) {
+      @Nonnull Collection<? extends JsonNode> samples, @Nullable String type, @Nonnull String path) {
     final GenericSchemaFeatureInput input =
-        new GenericSchemaFeatureInput(schema, samples, type, specVersion);
+        new GenericSchemaFeatureInput(schema, samples, type, specVersion, path);
     final ObjectNode featureResult = genericSchemaFeature.getFeatureResult(input);
     if (featureResult != null) {
       schema.setAll(featureResult);

--- a/src/test/java/com/saasquatch/jsonschemainferrer/JsonSchemaInferrerOptionsTest.java
+++ b/src/test/java/com/saasquatch/jsonschemainferrer/JsonSchemaInferrerOptionsTest.java
@@ -1,38 +1,28 @@
 package com.saasquatch.jsonschemainferrer;
 
-import static com.saasquatch.jsonschemainferrer.JunkDrawer.stream;
-import static com.saasquatch.jsonschemainferrer.TestJunkDrawer.jnf;
-import static com.saasquatch.jsonschemainferrer.TestJunkDrawer.toStringSet;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.Month;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
-import org.junit.jupiter.api.Test;
+
+import static com.saasquatch.jsonschemainferrer.JunkDrawer.stream;
+import static com.saasquatch.jsonschemainferrer.TestJunkDrawer.jnf;
+import static com.saasquatch.jsonschemainferrer.TestJunkDrawer.toStringSet;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class JsonSchemaInferrerOptionsTest {
 
@@ -394,7 +384,7 @@ public class JsonSchemaInferrerOptionsTest {
     {
       final JsonNode examples =
           ExamplesPolicies.useFirstSamples(1).getExamples(new GenericSchemaFeatureInput(
-              jnf.objectNode(), Collections.emptyList(), "string", SpecVersion.DRAFT_07));
+              jnf.objectNode(), Collections.emptyList(), "string", SpecVersion.DRAFT_07, "$"));
       assertNull(examples);
     }
     {

--- a/src/test/java/com/saasquatch/jsonschemainferrer/PathProvidedTest.java
+++ b/src/test/java/com/saasquatch/jsonschemainferrer/PathProvidedTest.java
@@ -1,6 +1,7 @@
 package com.saasquatch.jsonschemainferrer;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -30,22 +31,22 @@ public class PathProvidedTest {
 
     @Test
     public void genericFeatureTest() {
-        Queue<String> expected = new LinkedList<>(List.of("$.id",
-                                                          "$.slug",
-                                                          "$.admin",
-                                                          "$.avatar",
-                                                          "$.date",
-                                                          "$.article.title",
-                                                          "$.article.description",
-                                                          "$.article.body",
-                                                          "$.article",
-                                                          "$.comments[*].body",
-                                                          "$.comments[*].body",
-                                                          "$.comments[*].tags[*]",
-                                                          "$.comments[*].tags[*]",
-                                                          "$.comments[*].tags",
-                                                          "$.comments[*]",
-                                                          "$.comments",
+        Queue<String> expected = new LinkedList<>(List.of("$[\"id\"]",
+                                                          "$[\"slug\"]",
+                                                          "$[\"admin\"]",
+                                                          "$[\"avatar\"]",
+                                                          "$[\"date\"]",
+                                                          "$[\"article\"][\"title\"]",
+                                                          "$[\"article\"][\"description\"]",
+                                                          "$[\"article\"][\"body\"]",
+                                                          "$[\"article\"]",
+                                                          "$[\"comments\"][*][\"body\"]",
+                                                          "$[\"comments\"][*][\"body\"]",
+                                                          "$[\"comments\"][*][\"tags\"][*]",
+                                                          "$[\"comments\"][*][\"tags\"][*]",
+                                                          "$[\"comments\"][*][\"tags\"]",
+                                                          "$[\"comments\"][*]",
+                                                          "$[\"comments\"]",
                                                           "$"));
         final JsonNode jsonNode = loadJson("simple.json");
         final JsonSchemaInferrer inferrer = JsonSchemaInferrer.newBuilder().addGenericSchemaFeatures(input -> {
@@ -56,8 +57,35 @@ public class PathProvidedTest {
     }
 
     @Test
+    public void testSpecialCharacters(){
+        Queue<String> expected = new LinkedList<>(List.of("$[\"foo[\\\"bar\\\"]\"]", "$"));
+        final String fieldName = "foo[\"bar\"]";
+        final JsonNode root = JsonNodeFactory.instance.objectNode()
+                                                      .put(fieldName, 42);
+        final JsonSchemaInferrer inferrer = JsonSchemaInferrer.newBuilder().addGenericSchemaFeatures(input -> {
+            assertEquals(expected.poll(), input.getPath());
+            return null;
+        }).build();
+        inferrer.inferForSample(root);
+    }
+
+    @Test
     public void enumExtractorTest() {
-        Queue<String> expected = new LinkedList<>(List.of("$"));
+        Queue<String> expected = new LinkedList<>(List.of("$",
+                                                          "$[\"id\"]",
+                                                          "$[\"slug\"]",
+                                                          "$[\"admin\"]",
+                                                          "$[\"avatar\"]",
+                                                          "$[\"date\"]",
+                                                          "$[\"article\"]",
+                                                          "$[\"article\"][\"title\"]",
+                                                          "$[\"article\"][\"description\"]",
+                                                          "$[\"article\"][\"body\"]",
+                                                          "$[\"comments\"]",
+                                                          "$[\"comments\"][*]",
+                                                          "$[\"comments\"][*][\"body\"]",
+                                                          "$[\"comments\"][*][\"tags\"]",
+                                                          "$[\"comments\"][*][\"tags\"][*]"));
         final JsonNode jsonNode = loadJson("simple.json");
         final JsonSchemaInferrer inferrer = JsonSchemaInferrer.newBuilder().addEnumExtractors(input -> {
             assertEquals(expected.poll(), input.getPath());
@@ -68,20 +96,22 @@ public class PathProvidedTest {
 
     @Test
     public void formatInferTest() {
-        Queue<String> expected = new LinkedList<>(List.of("$.id",
-                                                          "$.slug",
-                                                          "$.admin",
-                                                          "$.avatar",
-                                                          "$.date",
-                                                          "$.article.title",
-                                                          "$.article.description",
-                                                          "$.article.body",
-                                                          "$.comments[*].body",
-                                                          "$.comments[*].body",
-                                                          "$.comments[*].body",
-                                                          "$.comments[*].tags[*]",
-                                                          "$.comments[*].tags[*]",
-                                                          "$.comments[*].tags[*]",
+        Queue<String> expected = new LinkedList<>(List.of("$[\"id\"]",
+                                                          "$[\"slug\"]",
+                                                          "$[\"admin\"]",
+                                                          "$[\"avatar\"]",
+                                                          "$[\"date\"]",
+                                                          "$[\"article\"][\"title\"]",
+                                                          "$[\"article\"][\"description\"]",
+                                                          "$[\"article\"][\"body\"]",
+                                                          "$[\"comments\"][*][\"body\"]",
+                                                          "$[\"comments\"][*][\"body\"]",
+                                                          "$[\"comments\"][*][\"body\"]",
+                                                          "$[\"comments\"][*][\"tags\"][*]",
+                                                          "$[\"comments\"][*][\"tags\"][*]",
+                                                          "$[\"comments\"][*][\"tags\"][*]",
+                                                          "$[\"comments\"][*]",
+                                                          "$[\"comments\"]",
                                                           "$"));
         final JsonNode jsonNode = loadJson("simple.json");
         final JsonSchemaInferrer inferrer = JsonSchemaInferrer.newBuilder().addFormatInferrers(input -> {

--- a/src/test/java/com/saasquatch/jsonschemainferrer/PathProvidedTest.java
+++ b/src/test/java/com/saasquatch/jsonschemainferrer/PathProvidedTest.java
@@ -1,0 +1,94 @@
+package com.saasquatch.jsonschemainferrer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+import static com.saasquatch.jsonschemainferrer.TestJunkDrawer.mapper;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author sbroekhuis
+ */
+public class PathProvidedTest {
+
+    @SuppressWarnings("SameParameterValue")
+    private JsonNode loadJson(String fileName) {
+        try (InputStream in = this.getClass().getResourceAsStream(fileName)) {
+            return mapper.readTree(in);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Test
+    public void genericFeatureTest() {
+        Queue<String> expected = new LinkedList<>(List.of("$.id",
+                                                          "$.slug",
+                                                          "$.admin",
+                                                          "$.avatar",
+                                                          "$.date",
+                                                          "$.article.title",
+                                                          "$.article.description",
+                                                          "$.article.body",
+                                                          "$.article",
+                                                          "$.comments[*].body",
+                                                          "$.comments[*].body",
+                                                          "$.comments[*].tags[*]",
+                                                          "$.comments[*].tags[*]",
+                                                          "$.comments[*].tags",
+                                                          "$.comments[*]",
+                                                          "$.comments",
+                                                          "$"));
+        final JsonNode jsonNode = loadJson("simple.json");
+        final JsonSchemaInferrer inferrer = JsonSchemaInferrer.newBuilder().addGenericSchemaFeatures(input -> {
+            assertEquals(expected.poll(), input.getPath());
+            return null;
+        }).build();
+        inferrer.inferForSample(jsonNode);
+    }
+
+    @Test
+    public void enumExtractorTest() {
+        Queue<String> expected = new LinkedList<>(List.of("$"));
+        final JsonNode jsonNode = loadJson("simple.json");
+        final JsonSchemaInferrer inferrer = JsonSchemaInferrer.newBuilder().addEnumExtractors(input -> {
+            assertEquals(expected.poll(), input.getPath());
+            return Collections.emptySet();
+        }).build();
+        inferrer.inferForSample(jsonNode);
+    }
+
+    @Test
+    public void formatInferTest() {
+        Queue<String> expected = new LinkedList<>(List.of("$.id",
+                                                          "$.slug",
+                                                          "$.admin",
+                                                          "$.avatar",
+                                                          "$.date",
+                                                          "$.article.title",
+                                                          "$.article.description",
+                                                          "$.article.body",
+                                                          "$.comments[*].body",
+                                                          "$.comments[*].body",
+                                                          "$.comments[*].body",
+                                                          "$.comments[*].tags[*]",
+                                                          "$.comments[*].tags[*]",
+                                                          "$.comments[*].tags[*]",
+                                                          "$"));
+        final JsonNode jsonNode = loadJson("simple.json");
+        final JsonSchemaInferrer inferrer = JsonSchemaInferrer.newBuilder().addFormatInferrers(input -> {
+            assertEquals(expected.poll(), input.getPath());
+            return null;
+        }).build();
+        inferrer.inferForSample(jsonNode);
+    }
+
+}


### PR DESCRIPTION
## Description of the change

Added `path` parameters to most of the methods. Allowing to see the path in the following classes:
- GenericSchemaFeatureInput
- FormatInferrerInput
- EnumExtractorInput

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

Resolve #16. Using json path we can see the 'key'. 

## Notes

- I tried not to run any style format.
- I added `@Nonnull` where applicable.
- A simple test was written to check if the path is correct.
- All other tests are still green, but some needed adjustment as they needed a `path` parameter. I set them to `"$"` but they don't use it anyway.
